### PR TITLE
[Build] Make it a dang module

### DIFF
--- a/.changeset/witty-tigers-change.md
+++ b/.changeset/witty-tigers-change.md
@@ -1,0 +1,5 @@
+---
+"@kilmc/music-fns": minor
+---
+
+Convert package to module

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "version": "0.4.0",
   "main": "dist/bundle.js",
   "types": "dist/main.d.ts",
+  "type": "module",
   "publishConfig": {
     "access": "public"
   },


### PR DESCRIPTION
I think Sveltekit is marking it as a CommonJS package because that seems to be the default, you gotta set it as a `type: module`. Let's see if this works.